### PR TITLE
Update Install Poetry  command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Paper.
     analysis on the cluster. Install Poetry by running the command in the
     [official Poetry installation instructions]:
 
-        $ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python
+        $ curl -sSL https://install.python-poetry.org | python3 -
 
     Then log out, and log back in.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Paper.
     analysis on the cluster. Install Poetry by running the command in the
     [official Poetry installation instructions]:
 
-        $ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+        $ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python
 
     Then log out, and log back in.
 


### PR DESCRIPTION
Now to install Poetry, we need to replace " get-poetry.py"  by  "install-poetry.py". Otherwise it return  this error:

  File "<stdin>", line 1
    404: Not Found
    ^
SyntaxError: illegal target for annotation